### PR TITLE
fix: solve QueryClient error by using peerDependencies

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2974,6 +2974,7 @@ const RAW_RUNTIME_STATE =
           ["axios", "npm:1.15.0"],\
           ["date-fns", "npm:4.1.0"],\
           ["file-saver", "npm:2.0.5"],\
+          ["react", "npm:18.3.1"],\
           ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
         ],\
@@ -2985,7 +2986,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/hooks/",\
         "packageDependencies": [\
           ["@dms/hooks", "workspace:packages/hooks"],\
-          ["@tanstack/react-query", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:4.29.12"],\
+          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
           ["@team-aliens/design-system", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:1.14.5"],\
           ["@types/file-saver", "npm:2.0.7"],\
           ["@types/node", "npm:18.19.130"],\
@@ -2993,7 +2994,7 @@ const RAW_RUNTIME_STATE =
           ["date-fns", "npm:4.1.0"],\
           ["file-saver", "npm:2.0.5"],\
           ["react", "npm:18.3.1"],\
-          ["react-router-dom", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:6.30.3"],\
+          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
         ],\
         "linkType": "SOFT"\
@@ -3004,7 +3005,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/store/",\
         "packageDependencies": [\
           ["@dms/store", "workspace:packages/store"],\
-          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
+          ["@tanstack/react-query", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.29.12"],\
           ["@team-aliens/design-system", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:1.14.5"],\
           ["@types/file-saver", "npm:2.0.7"],\
           ["@types/node", "npm:18.19.130"],\
@@ -3014,7 +3015,7 @@ const RAW_RUNTIME_STATE =
           ["file-saver", "npm:2.0.5"],\
           ["mitt", "npm:3.0.1"],\
           ["react-cookie", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.1.1"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
+          ["react-router-dom", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"],\
           ["zustand", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.5.7"]\
         ],\
@@ -3026,7 +3027,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/utils/",\
         "packageDependencies": [\
           ["@dms/utils", "workspace:packages/utils"],\
-          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
+          ["@tanstack/react-query", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.29.12"],\
           ["@team-aliens/design-system", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:1.14.5"],\
           ["@types/file-saver", "npm:2.0.7"],\
           ["@types/node", "npm:18.19.130"],\
@@ -3036,7 +3037,7 @@ const RAW_RUNTIME_STATE =
           ["file-saver", "npm:2.0.5"],\
           ["mitt", "npm:3.0.1"],\
           ["react-cookie", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.1.1"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
+          ["react-router-dom", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
         ],\
         "linkType": "SOFT"\
@@ -4449,7 +4450,7 @@ const RAW_RUNTIME_STATE =
           ["@types/react", null],\
           ["@types/react-dom", null],\
           ["@types/react-native", null],\
-          ["react", null],\
+          ["react", "npm:18.3.1"],\
           ["react-dom", null],\
           ["react-native", null],\
           ["use-sync-external-store", "virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0"]\
@@ -4464,18 +4465,18 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:4.29.12", {\
-        "packageLocation": "./.yarn/__virtual__/@tanstack-react-query-virtual-49d6a717d1/0/cache/@tanstack-react-query-npm-4.29.12-5b8b58ce34-f6dae856b0.zip/node_modules/@tanstack/react-query/",\
+      ["virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.29.12", {\
+        "packageLocation": "./.yarn/__virtual__/@tanstack-react-query-virtual-346804e7cf/0/cache/@tanstack-react-query-npm-4.29.12-5b8b58ce34-f6dae856b0.zip/node_modules/@tanstack/react-query/",\
         "packageDependencies": [\
-          ["@tanstack/react-query", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:4.29.12"],\
+          ["@tanstack/react-query", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.29.12"],\
           ["@tanstack/query-core", "npm:4.29.11"],\
           ["@types/react", null],\
           ["@types/react-dom", null],\
           ["@types/react-native", null],\
-          ["react", "npm:18.3.1"],\
+          ["react", null],\
           ["react-dom", null],\
           ["react-native", null],\
-          ["use-sync-external-store", "virtual:49d6a717d1a67481179e4f2d9e655bc2d026acd7c1e6cfd08947cbd948168284f3b2e0d98101c836c21b9547608c7f5b33933be7d624926d0a8f291551dbc0a7#npm:1.6.0"]\
+          ["use-sync-external-store", "virtual:346804e7cf9a4b03429f0441d021a8d8d408292dfb6df8edb2bdfa5d47fad6da2fadc79eb0a73f2a2fc2005860cc43246a3bbc939729ca14d8164da451626cf4#npm:1.6.0"]\
         ],\
         "packagePeers": [\
           "@types/react-dom",\
@@ -4589,7 +4590,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:18.3.1"],\
           ["react-dom", null],\
           ["react-outside-click-handler", "virtual:cccf0ed556f67b067c6ea4c3574ff9f12107b51233800130f6acdc39d6e0a16594a1c7f6056b31c0cbf013f449cfb357d238383de34e6ea94350d8a3e9baca51#npm:1.3.0"],\
-          ["react-router-dom", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:6.30.3"],\
+          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
           ["styled-components", null]\
         ],\
         "packagePeers": [\
@@ -4615,7 +4616,7 @@ const RAW_RUNTIME_STATE =
           ["react", null],\
           ["react-dom", null],\
           ["react-outside-click-handler", "virtual:ac1b124233986f516a58fe83dbd79ef3f9715d3b9aafaee903a2236b19edaa581dfb2a3ca861e413d3624867a65519240a461bd226e275bf9954ebfad8cf39cd#npm:1.3.0"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
+          ["react-router-dom", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3"],\
           ["styled-components", null]\
         ],\
         "packagePeers": [\
@@ -12428,7 +12429,7 @@ const RAW_RUNTIME_STATE =
           ["react-router", "virtual:140e240db8ca33a77368e37ad56c4270b16d61eed4aee33b3d10bea6fa537f705f87be0b48d9e0f2e30c9731c7b5bafc673e5eaecd97ff725a5cbc92ec4b5936#npm:6.30.3"],\
           ["@remix-run/router", "npm:1.23.2"],\
           ["@types/react", null],\
-          ["react", null]\
+          ["react", "npm:18.3.1"]\
         ],\
         "packagePeers": [\
           "@types/react",\
@@ -12436,13 +12437,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:87de4b3d811ae3d3e6e56f5e4d32513dbcd0d33b93c32f1c4ee5f065b9d8c2b8d340c33f7078ad56ba3dc5ceddc6d176c247246d91cbb4129ac869413080cfe1#npm:6.30.3", {\
-        "packageLocation": "./.yarn/__virtual__/react-router-virtual-bb619d898d/0/cache/react-router-npm-6.30.3-fc99f1d4aa-1a51bdcc42.zip/node_modules/react-router/",\
+      ["virtual:3fc8e16dee77c63842de8c88a01858d5a0a8a5093c5e8f11197f3d5b7e1f55ae50f23481fd000c2f7178543ff982534bda70bae239c4fcedc758f248f63b8b8e#npm:6.30.3", {\
+        "packageLocation": "./.yarn/__virtual__/react-router-virtual-c30bc7c5ad/0/cache/react-router-npm-6.30.3-fc99f1d4aa-1a51bdcc42.zip/node_modules/react-router/",\
         "packageDependencies": [\
-          ["react-router", "virtual:87de4b3d811ae3d3e6e56f5e4d32513dbcd0d33b93c32f1c4ee5f065b9d8c2b8d340c33f7078ad56ba3dc5ceddc6d176c247246d91cbb4129ac869413080cfe1#npm:6.30.3"],\
+          ["react-router", "virtual:3fc8e16dee77c63842de8c88a01858d5a0a8a5093c5e8f11197f3d5b7e1f55ae50f23481fd000c2f7178543ff982534bda70bae239c4fcedc758f248f63b8b8e#npm:6.30.3"],\
           ["@remix-run/router", "npm:1.23.2"],\
           ["@types/react", null],\
-          ["react", "npm:18.3.1"]\
+          ["react", null]\
         ],\
         "packagePeers": [\
           "@types/react",\
@@ -12466,7 +12467,7 @@ const RAW_RUNTIME_STATE =
           ["@remix-run/router", "npm:1.23.2"],\
           ["@types/react", null],\
           ["@types/react-dom", null],\
-          ["react", null],\
+          ["react", "npm:18.3.1"],\
           ["react-dom", null],\
           ["react-router", "virtual:140e240db8ca33a77368e37ad56c4270b16d61eed4aee33b3d10bea6fa537f705f87be0b48d9e0f2e30c9731c7b5bafc673e5eaecd97ff725a5cbc92ec4b5936#npm:6.30.3"]\
         ],\
@@ -12478,16 +12479,16 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:6.30.3", {\
-        "packageLocation": "./.yarn/__virtual__/react-router-dom-virtual-87de4b3d81/0/cache/react-router-dom-npm-6.30.3-232cfedb2d-db974d8010.zip/node_modules/react-router-dom/",\
+      ["virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3", {\
+        "packageLocation": "./.yarn/__virtual__/react-router-dom-virtual-3fc8e16dee/0/cache/react-router-dom-npm-6.30.3-232cfedb2d-db974d8010.zip/node_modules/react-router-dom/",\
         "packageDependencies": [\
-          ["react-router-dom", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:6.30.3"],\
+          ["react-router-dom", "virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3"],\
           ["@remix-run/router", "npm:1.23.2"],\
           ["@types/react", null],\
           ["@types/react-dom", null],\
-          ["react", "npm:18.3.1"],\
+          ["react", null],\
           ["react-dom", null],\
-          ["react-router", "virtual:87de4b3d811ae3d3e6e56f5e4d32513dbcd0d33b93c32f1c4ee5f065b9d8c2b8d340c33f7078ad56ba3dc5ceddc6d176c247246d91cbb4129ac869413080cfe1#npm:6.30.3"]\
+          ["react-router", "virtual:3fc8e16dee77c63842de8c88a01858d5a0a8a5093c5e8f11197f3d5b7e1f55ae50f23481fd000c2f7178543ff982534bda70bae239c4fcedc758f248f63b8b8e#npm:6.30.3"]\
         ],\
         "packagePeers": [\
           "@types/react-dom",\
@@ -14343,6 +14344,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["virtual:346804e7cf9a4b03429f0441d021a8d8d408292dfb6df8edb2bdfa5d47fad6da2fadc79eb0a73f2a2fc2005860cc43246a3bbc939729ca14d8164da451626cf4#npm:1.6.0", {\
+        "packageLocation": "./.yarn/__virtual__/use-sync-external-store-virtual-7c2a8b817a/0/cache/use-sync-external-store-npm-1.6.0-2db2af616d-b40ad2847b.zip/node_modules/use-sync-external-store/",\
+        "packageDependencies": [\
+          ["use-sync-external-store", "virtual:346804e7cf9a4b03429f0441d021a8d8d408292dfb6df8edb2bdfa5d47fad6da2fadc79eb0a73f2a2fc2005860cc43246a3bbc939729ca14d8164da451626cf4#npm:1.6.0"],\
+          ["@types/react", null],\
+          ["react", null]\
+        ],\
+        "packagePeers": [\
+          "@types/react",\
+          "react"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:34a93787364705291e9b4ba3993458141c19aa89c1ade28b6f47a6ce511794283849a079b41b7125f8bbff49dbe47d20d0472009edd50d2d9c6042f17836bd66#npm:1.6.0", {\
         "packageLocation": "./.yarn/__virtual__/use-sync-external-store-virtual-6442b93ac3/0/cache/use-sync-external-store-npm-1.6.0-2db2af616d-b40ad2847b.zip/node_modules/use-sync-external-store/",\
         "packageDependencies": [\
@@ -14356,25 +14370,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:49d6a717d1a67481179e4f2d9e655bc2d026acd7c1e6cfd08947cbd948168284f3b2e0d98101c836c21b9547608c7f5b33933be7d624926d0a8f291551dbc0a7#npm:1.6.0", {\
-        "packageLocation": "./.yarn/__virtual__/use-sync-external-store-virtual-3ddd8a4e2e/0/cache/use-sync-external-store-npm-1.6.0-2db2af616d-b40ad2847b.zip/node_modules/use-sync-external-store/",\
-        "packageDependencies": [\
-          ["use-sync-external-store", "virtual:49d6a717d1a67481179e4f2d9e655bc2d026acd7c1e6cfd08947cbd948168284f3b2e0d98101c836c21b9547608c7f5b33933be7d624926d0a8f291551dbc0a7#npm:1.6.0"],\
-          ["@types/react", null],\
-          ["react", "npm:18.3.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0", {\
         "packageLocation": "./.yarn/__virtual__/use-sync-external-store-virtual-ec14616aad/0/cache/use-sync-external-store-npm-1.6.0-2db2af616d-b40ad2847b.zip/node_modules/use-sync-external-store/",\
         "packageDependencies": [\
           ["use-sync-external-store", "virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0"],\
           ["@types/react", null],\
-          ["react", null]\
+          ["react", "npm:18.3.1"]\
         ],\
         "packagePeers": [\
           "@types/react",\
@@ -14861,7 +14862,7 @@ const RAW_RUNTIME_STATE =
           ["@types/react", null],\
           ["immer", null],\
           ["react", null],\
-          ["use-sync-external-store", "virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0"]\
+          ["use-sync-external-store", "virtual:346804e7cf9a4b03429f0441d021a8d8d408292dfb6df8edb2bdfa5d47fad6da2fadc79eb0a73f2a2fc2005860cc43246a3bbc939729ca14d8164da451626cf4#npm:1.6.0"]\
         ],\
         "packagePeers": [\
           "@types/immer",\

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -5,15 +5,21 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "dependencies": {
-    "@tanstack/react-query": "4.29.12",
     "axios": "^1.1.3",
     "date-fns": "^4.1.0",
-    "file-saver": "^2.0.5",
+    "file-saver": "^2.0.5"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "4.29.12",
+    "react": ">=18",
     "react-router-dom": "^6.4.2"
   },
   "devDependencies": {
+    "@tanstack/react-query": "4.29.12",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^18.11.18",
+    "react": "^18.2.0",
+    "react-router-dom": "^6.4.2",
     "typescript": "^4.9.4"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,17 +5,22 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "dependencies": {
-    "@tanstack/react-query": "4.29.12",
     "@team-aliens/design-system": "^1.14.5",
     "axios": "^1.1.3",
     "date-fns": "^4.1.0",
-    "file-saver": "^2.0.5",
+    "file-saver": "^2.0.5"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "4.29.12",
+    "react": ">=18",
     "react-router-dom": "^6.4.2"
   },
   "devDependencies": {
+    "@tanstack/react-query": "4.29.12",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^18.11.18",
     "react": "^18.2.0",
+    "react-router-dom": "^6.4.2",
     "typescript": "^4.9.4"
   }
 }

--- a/packages/hooks/src/useDaybreakApi.tsx
+++ b/packages/hooks/src/useDaybreakApi.tsx
@@ -25,7 +25,7 @@ export const commonQueryOptions = (pageSize: number = 10) => ({
   cacheTime: 0,
   staleTime: 0,
   getNextPageParam: (lastPage: any, allPages: any[]) => {
-    const currentItems = lastPage.applications || [];
+    const currentItems = lastPage?.applications || [];
 
     if (currentItems.length < pageSize || currentItems.length === 0) {
       return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,8 +1516,13 @@ __metadata:
     axios: "npm:^1.1.3"
     date-fns: "npm:^4.1.0"
     file-saver: "npm:^2.0.5"
+    react: "npm:^18.2.0"
     react-router-dom: "npm:^6.4.2"
     typescript: "npm:^4.9.4"
+  peerDependencies:
+    "@tanstack/react-query": 4.29.12
+    react: ">=18"
+    react-router-dom: ^6.4.2
   languageName: unknown
   linkType: soft
 
@@ -1535,6 +1540,10 @@ __metadata:
     react: "npm:^18.2.0"
     react-router-dom: "npm:^6.4.2"
     typescript: "npm:^4.9.4"
+  peerDependencies:
+    "@tanstack/react-query": 4.29.12
+    react: ">=18"
+    react-router-dom: ^6.4.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 개요
모노레포 패키지 분리 후 발생한 No QueryClient set 에러 해결 및 의존성 구조 최적화
## 이슈 번호

- closes #169 

## 변경사항 
- 의존성 최적화: 공통 패키지의 react-query를 peerDependencies로 변경하여 인스턴스 중복 방지
