### PR TITLE
fix(admin): 빌드 시 라이브러리 중복 인스턴스 및 PnP 경로 에러 수정

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2968,14 +2968,11 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/apis/",\
         "packageDependencies": [\
           ["@dms/apis", "workspace:packages/apis"],\
-          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
           ["@types/file-saver", "npm:2.0.7"],\
           ["@types/node", "npm:18.19.130"],\
           ["axios", "npm:1.15.0"],\
           ["date-fns", "npm:4.1.0"],\
           ["file-saver", "npm:2.0.5"],\
-          ["react", "npm:18.3.1"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
         ],\
         "linkType": "SOFT"\
@@ -2986,15 +2983,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/hooks/",\
         "packageDependencies": [\
           ["@dms/hooks", "workspace:packages/hooks"],\
-          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
           ["@team-aliens/design-system", "virtual:cff5a1003aa2973306bbd3c5377f1bc422bb5a020c7f72948b3d31112f6d749811ded090fd486ed830104b85692601457aacedbccc162903206361b5ac17d2b9#npm:1.14.5"],\
           ["@types/file-saver", "npm:2.0.7"],\
           ["@types/node", "npm:18.19.130"],\
           ["axios", "npm:1.15.0"],\
           ["date-fns", "npm:4.1.0"],\
           ["file-saver", "npm:2.0.5"],\
-          ["react", "npm:18.3.1"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
         ],\
         "linkType": "SOFT"\
@@ -4442,29 +4436,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12", {\
-        "packageLocation": "./.yarn/__virtual__/@tanstack-react-query-virtual-73af6fdf62/0/cache/@tanstack-react-query-npm-4.29.12-5b8b58ce34-f6dae856b0.zip/node_modules/@tanstack/react-query/",\
-        "packageDependencies": [\
-          ["@tanstack/react-query", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:4.29.12"],\
-          ["@tanstack/query-core", "npm:4.29.11"],\
-          ["@types/react", null],\
-          ["@types/react-dom", null],\
-          ["@types/react-native", null],\
-          ["react", "npm:18.3.1"],\
-          ["react-dom", null],\
-          ["react-native", null],\
-          ["use-sync-external-store", "virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/react-dom",\
-          "@types/react-native",\
-          "@types/react",\
-          "react-dom",\
-          "react-native",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:4.29.12", {\
         "packageLocation": "./.yarn/__virtual__/@tanstack-react-query-virtual-346804e7cf/0/cache/@tanstack-react-query-npm-4.29.12-5b8b58ce34-f6dae856b0.zip/node_modules/@tanstack/react-query/",\
         "packageDependencies": [\
@@ -4618,10 +4589,10 @@ const RAW_RUNTIME_STATE =
           ["@types/react-dom", null],\
           ["@types/react-router-dom", null],\
           ["@types/styled-components", null],\
-          ["react", "npm:18.3.1"],\
+          ["react", null],\
           ["react-dom", null],\
-          ["react-outside-click-handler", "virtual:cccf0ed556f67b067c6ea4c3574ff9f12107b51233800130f6acdc39d6e0a16594a1c7f6056b31c0cbf013f449cfb357d238383de34e6ea94350d8a3e9baca51#npm:1.3.0"],\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
+          ["react-outside-click-handler", "virtual:ac1b124233986f516a58fe83dbd79ef3f9715d3b9aafaee903a2236b19edaa581dfb2a3ca861e413d3624867a65519240a461bd226e275bf9954ebfad8cf39cd#npm:1.3.0"],\
+          ["react-router-dom", null],\
           ["styled-components", null]\
         ],\
         "packagePeers": [\
@@ -5696,28 +5667,6 @@ const RAW_RUNTIME_STATE =
           ["airbnb-prop-types", "npm:2.16.0"]\
         ],\
         "linkType": "SOFT"\
-      }],\
-      ["virtual:0d6b4f22de3787a4333551616a4fc40263e87954f4d1ec4753a04f725db54a134e572e709dd9822899d00a0fca078c38b8c56e6993c781fea23755b4ddc69610#npm:2.16.0", {\
-        "packageLocation": "./.yarn/__virtual__/airbnb-prop-types-virtual-c6c28cb34d/0/cache/airbnb-prop-types-npm-2.16.0-d794f5271c-8f87960bad.zip/node_modules/airbnb-prop-types/",\
-        "packageDependencies": [\
-          ["airbnb-prop-types", "virtual:0d6b4f22de3787a4333551616a4fc40263e87954f4d1ec4753a04f725db54a134e572e709dd9822899d00a0fca078c38b8c56e6993c781fea23755b4ddc69610#npm:2.16.0"],\
-          ["@types/react", null],\
-          ["array.prototype.find", "npm:2.2.3"],\
-          ["function.prototype.name", "npm:1.1.8"],\
-          ["is-regex", "npm:1.2.1"],\
-          ["object-is", "npm:1.1.6"],\
-          ["object.assign", "npm:4.1.7"],\
-          ["object.entries", "npm:1.1.9"],\
-          ["prop-types", "npm:15.8.1"],\
-          ["prop-types-exact", "npm:1.2.7"],\
-          ["react", "npm:18.3.1"],\
-          ["react-is", "npm:16.13.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
       }],\
       ["virtual:a09617f34aff4d5408a4e1209bd37d78ff647dd3f6c8629127837b7565b1ecc1de6cd5fd20ef876614116544f9e33056ed18001450b6365c57e07bb97273473e#npm:2.16.0", {\
         "packageLocation": "./.yarn/__virtual__/airbnb-prop-types-virtual-08f06cd8f9/0/cache/airbnb-prop-types-npm-2.16.0-d794f5271c-8f87960bad.zip/node_modules/airbnb-prop-types/",\
@@ -12378,28 +12327,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:cccf0ed556f67b067c6ea4c3574ff9f12107b51233800130f6acdc39d6e0a16594a1c7f6056b31c0cbf013f449cfb357d238383de34e6ea94350d8a3e9baca51#npm:1.3.0", {\
-        "packageLocation": "./.yarn/__virtual__/react-outside-click-handler-virtual-0d6b4f22de/0/cache/react-outside-click-handler-npm-1.3.0-7fa0d196a3-ab9ffbea36.zip/node_modules/react-outside-click-handler/",\
-        "packageDependencies": [\
-          ["react-outside-click-handler", "virtual:cccf0ed556f67b067c6ea4c3574ff9f12107b51233800130f6acdc39d6e0a16594a1c7f6056b31c0cbf013f449cfb357d238383de34e6ea94350d8a3e9baca51#npm:1.3.0"],\
-          ["@types/react", null],\
-          ["@types/react-dom", null],\
-          ["airbnb-prop-types", "virtual:0d6b4f22de3787a4333551616a4fc40263e87954f4d1ec4753a04f725db54a134e572e709dd9822899d00a0fca078c38b8c56e6993c781fea23755b4ddc69610#npm:2.16.0"],\
-          ["consolidated-events", "npm:2.0.2"],\
-          ["document.contains", "npm:1.0.2"],\
-          ["object.values", "npm:1.2.1"],\
-          ["prop-types", "npm:15.8.1"],\
-          ["react", "npm:18.3.1"],\
-          ["react-dom", null]\
-        ],\
-        "packagePeers": [\
-          "@types/react-dom",\
-          "@types/react",\
-          "react-dom",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:f25dfec009a3ba8ebeba1872e43e47be86fc3cbba3f68e94f1a9ecc5b98c0352de221afd3123b8ec53c59d98bf57522fd8773136e3ce8b115c6f503ffd871dc7#npm:1.3.0", {\
         "packageLocation": "./.yarn/__virtual__/react-outside-click-handler-virtual-a09617f34a/0/cache/react-outside-click-handler-npm-1.3.0-7fa0d196a3-ab9ffbea36.zip/node_modules/react-outside-click-handler/",\
         "packageDependencies": [\
@@ -12454,20 +12381,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:140e240db8ca33a77368e37ad56c4270b16d61eed4aee33b3d10bea6fa537f705f87be0b48d9e0f2e30c9731c7b5bafc673e5eaecd97ff725a5cbc92ec4b5936#npm:6.30.3", {\
-        "packageLocation": "./.yarn/__virtual__/react-router-virtual-cf02f8c69d/0/cache/react-router-npm-6.30.3-fc99f1d4aa-1a51bdcc42.zip/node_modules/react-router/",\
-        "packageDependencies": [\
-          ["react-router", "virtual:140e240db8ca33a77368e37ad56c4270b16d61eed4aee33b3d10bea6fa537f705f87be0b48d9e0f2e30c9731c7b5bafc673e5eaecd97ff725a5cbc92ec4b5936#npm:6.30.3"],\
-          ["@remix-run/router", "npm:1.23.2"],\
-          ["@types/react", null],\
-          ["react", "npm:18.3.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:3fc8e16dee77c63842de8c88a01858d5a0a8a5093c5e8f11197f3d5b7e1f55ae50f23481fd000c2f7178543ff982534bda70bae239c4fcedc758f248f63b8b8e#npm:6.30.3", {\
         "packageLocation": "./.yarn/__virtual__/react-router-virtual-c30bc7c5ad/0/cache/react-router-npm-6.30.3-fc99f1d4aa-1a51bdcc42.zip/node_modules/react-router/",\
         "packageDependencies": [\
@@ -12490,25 +12403,6 @@ const RAW_RUNTIME_STATE =
           ["react-router-dom", "npm:6.30.3"]\
         ],\
         "linkType": "SOFT"\
-      }],\
-      ["virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3", {\
-        "packageLocation": "./.yarn/__virtual__/react-router-dom-virtual-140e240db8/0/cache/react-router-dom-npm-6.30.3-232cfedb2d-db974d8010.zip/node_modules/react-router-dom/",\
-        "packageDependencies": [\
-          ["react-router-dom", "virtual:0a5e72c9dd7df23a8512a7771b11a76dd5fb2abbb3a1c467bd061369441416f8429102fa7cfa0c5d17f5cfd06a96a6c6117aba2b546c104b3f03b18a79d706fb#npm:6.30.3"],\
-          ["@remix-run/router", "npm:1.23.2"],\
-          ["@types/react", null],\
-          ["@types/react-dom", null],\
-          ["react", "npm:18.3.1"],\
-          ["react-dom", null],\
-          ["react-router", "virtual:140e240db8ca33a77368e37ad56c4270b16d61eed4aee33b3d10bea6fa537f705f87be0b48d9e0f2e30c9731c7b5bafc673e5eaecd97ff725a5cbc92ec4b5936#npm:6.30.3"]\
-        ],\
-        "packagePeers": [\
-          "@types/react-dom",\
-          "@types/react",\
-          "react-dom",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
       }],\
       ["virtual:d8dd4fe791389ccf149b18bef1177e1945eabfefece11cae70fe6f88872d4613f065036d9199a002c52299ca6d924ad094db57f62ba23ea21eba96947825eeb7#npm:6.30.3", {\
         "packageLocation": "./.yarn/__virtual__/react-router-dom-virtual-3fc8e16dee/0/cache/react-router-dom-npm-6.30.3-232cfedb2d-db974d8010.zip/node_modules/react-router-dom/",\
@@ -14381,19 +14275,6 @@ const RAW_RUNTIME_STATE =
           ["use-sync-external-store", "virtual:346804e7cf9a4b03429f0441d021a8d8d408292dfb6df8edb2bdfa5d47fad6da2fadc79eb0a73f2a2fc2005860cc43246a3bbc939729ca14d8164da451626cf4#npm:1.6.0"],\
           ["@types/react", null],\
           ["react", null]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0", {\
-        "packageLocation": "./.yarn/__virtual__/use-sync-external-store-virtual-ec14616aad/0/cache/use-sync-external-store-npm-1.6.0-2db2af616d-b40ad2847b.zip/node_modules/use-sync-external-store/",\
-        "packageDependencies": [\
-          ["use-sync-external-store", "virtual:73af6fdf62b5f71f28b091d3d9f35bb5fe9ae96520569497a4737851649de30868e267824085174d637330738d2129f7ffd6d0291e62ed55ac8a44a8dcca3c79#npm:1.6.0"],\
-          ["@types/react", null],\
-          ["react", "npm:18.3.1"]\
         ],\
         "packagePeers": [\
           "@types/react",\

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -15,11 +15,8 @@
     "react-router-dom": "^6.4.2"
   },
   "devDependencies": {
-    "@tanstack/react-query": "4.29.12",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^18.11.18",
-    "react": "^18.2.0",
-    "react-router-dom": "^6.4.2",
     "typescript": "^4.9.4"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -16,11 +16,8 @@
     "react-router-dom": "^6.4.2"
   },
   "devDependencies": {
-    "@tanstack/react-query": "4.29.12",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^18.11.18",
-    "react": "^18.2.0",
-    "react-router-dom": "^6.4.2",
     "typescript": "^4.9.4"
   }
 }

--- a/services/admin/vite.config.ts
+++ b/services/admin/vite.config.ts
@@ -4,6 +4,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    preserveSymlinks: true,
+    dedupe: ['react', 'react-dom', 'react-router-dom', '@tanstack/react-query'],
+  },
   server: {
     port: 3000, // 개발 서버 포트
   },

--- a/services/generalTeacher/vite.config.ts
+++ b/services/generalTeacher/vite.config.ts
@@ -4,6 +4,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    preserveSymlinks: true,
+    dedupe: ['react', 'react-dom', 'react-router-dom', '@tanstack/react-query'],
+  },
   server: {
     port: 3001, // 개발 서버 포트
   },

--- a/services/headTeacher/vite.config.ts
+++ b/services/headTeacher/vite.config.ts
@@ -4,6 +4,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    preserveSymlinks: true,
+    dedupe: ['react', 'react-dom', 'react-router-dom', '@tanstack/react-query'],
+  },
   server: {
     port: 3001, // 개발 서버 포트
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,14 +1510,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dms/apis@workspace:packages/apis"
   dependencies:
-    "@tanstack/react-query": "npm:4.29.12"
     "@types/file-saver": "npm:^2.0.7"
     "@types/node": "npm:^18.11.18"
     axios: "npm:^1.1.3"
     date-fns: "npm:^4.1.0"
     file-saver: "npm:^2.0.5"
-    react: "npm:^18.2.0"
-    react-router-dom: "npm:^6.4.2"
     typescript: "npm:^4.9.4"
   peerDependencies:
     "@tanstack/react-query": 4.29.12
@@ -1530,15 +1527,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dms/hooks@workspace:packages/hooks"
   dependencies:
-    "@tanstack/react-query": "npm:4.29.12"
     "@team-aliens/design-system": "npm:^1.14.5"
     "@types/file-saver": "npm:^2.0.7"
     "@types/node": "npm:^18.11.18"
     axios: "npm:^1.1.3"
     date-fns: "npm:^4.1.0"
     file-saver: "npm:^2.0.5"
-    react: "npm:^18.2.0"
-    react-router-dom: "npm:^6.4.2"
     typescript: "npm:^4.9.4"
   peerDependencies:
     "@tanstack/react-query": 4.29.12


### PR DESCRIPTION
## 개요 
Yarn Berry PnP 환경에서 발생하는 빌드 경로 에러와 라이브러리 중복 인스턴스 문제 해결
## 이슈 번호

- closes #169 

## 변경사항 
- Vite 빌드 최적화: preserveSymlinks와 dedupe 설정을 추가하여 Yarn PnP 환경의 경로 에러 및 라이브러리 중복 인스턴스 문제 해결