### PR TITLE
fix: 잔류 서비스 매핑 에러 수정

### DIFF
--- a/packages/utils/src/serviceObjectToNavList.ts
+++ b/packages/utils/src/serviceObjectToNavList.ts
@@ -1,9 +1,12 @@
 import { Features, IsUseAbleFeature } from '@/apis/auth/response';
 import { ServiceToKorean, serviceToKorean } from '@/utils/translate';
 
-export const serviceObjectToNavList = (features: IsUseAbleFeature) =>
-  Object.entries(features)
-    .map((i: [Features, boolean]) => serviceToKorean(i[0]))
+export const serviceObjectToNavList = (features: IsUseAbleFeature) => {
+  const navList = (Object.entries(features) as [Features, boolean][])
+    // 예전엔 키 존재 여부만 보고 값(true/false)을 버렸다.
+    // 그래서 서버가 기능을 꺼도 메뉴가 남고, 응답에서 키가 빠지면 메뉴가 사라졌다.
+    .filter(([, isAvailable]) => isAvailable)
+    .map(([feature]) => serviceToKorean(feature))
     .concat({
       service: '설문',
       index: 3,
@@ -16,5 +19,11 @@ export const serviceObjectToNavList = (features: IsUseAbleFeature) =>
       service: '마이페이지',
       index: 4,
     })
+    // 매핑되지 않은 기능(index: -99)은 메뉴로 만들지 않는다
+    .filter((i) => i.service)
     .sort((prev, current) => prev.index - current.index)
     .map((i) => i.service) as ServiceToKorean[];
+
+  // meal_service와 daybreak_service가 같은 '새벽자습'으로 매핑돼 중복될 수 있다
+  return navList.filter((service, index) => navList.indexOf(service) === index);
+};

--- a/packages/utils/src/setUseableFeatures.ts
+++ b/packages/utils/src/setUseableFeatures.ts
@@ -1,7 +1,10 @@
 import { setCookie } from './cookies';
 import { serviceObjectToNavList } from '@/utils/serviceObjectToNavList';
 import { IsUseAbleFeature } from '@/apis/auth/response';
-export const setUseableFeatures = (features: IsUseAbleFeature) => {
+
+export const setUseableFeatures = (features?: IsUseAbleFeature) => {
+  if (!features) return;
+
   const featureToArr = serviceObjectToNavList(features);
   const expires = new Date();
   expires.setFullYear(expires.getFullYear() + 10);

--- a/packages/utils/src/translate.ts
+++ b/packages/utils/src/translate.ts
@@ -155,7 +155,10 @@ export interface ServiceObject {
 
 export const serviceToKorean = (service: Features): ServiceObject => {
   switch (service) {
-    case 'study_room_service':
+    // 자습실 도메인이 삭제되면서(백엔드 #1030) 응답에서 study_room_service가 사라졌고,
+    // '신청' 탭이 통째로 없어져 잔류(/apply/remains) 진입로까지 막혔었다.
+    // 현재 '신청' 탭에 남아있는 기능은 잔류뿐이라 remain_service 기준으로 판단한다.
+    case 'remain_service':
       return { service: '신청', index: 1 };
     case 'point_service':
       return { service: '홈', index: 0 };

--- a/services/admin/src/components/WithNavigatorBar.tsx
+++ b/services/admin/src/components/WithNavigatorBar.tsx
@@ -1,9 +1,9 @@
 import { NavigatorBar } from '@team-aliens/design-system';
 import styled from 'styled-components';
 import React, { useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import { getCookie } from '@/utils/cookies';
 import { ServiceToKorean } from '@/utils/translate';
+import { serviceObjectToNavList } from '@/utils/serviceObjectToNavList';
 import { useAvailAbleFeatures } from '@/hooks/useSchoolsApi';
 import { setUseableFeatures } from '@/utils/setUseableFeatures';
 
@@ -12,19 +12,23 @@ interface PropsType {
 }
 
 export function WithNavigatorBar({ children }: PropsType) {
-  const location = useLocation();
   const { data } = useAvailAbleFeatures();
 
+  // 예전엔 쿠키가 있으면 갱신하지 않아서(getCookie('service') || setUseableFeatures(data)),
+  // 만료 10년짜리 쿠키에 박힌 옛날 메뉴가 서버 응답이 바뀌어도 계속 남았다.
   useEffect(() => {
-    getCookie('service') || setUseableFeatures(data);
-  }, [getCookie('service')]);
+    setUseableFeatures(data);
+  }, [data]);
 
+  // 서버 응답이 도착하면 그걸 그대로 쓰고, 도착 전에는 쿠키로 그린다
   const services: ServiceToKorean[] = useMemo(
     () =>
-      ((getCookie('service') || '').split(',') as ServiceToKorean[]).filter(
-        (i) => i,
-      ),
-    [getCookie('service'), getCookie('access_token'), location],
+      data
+        ? serviceObjectToNavList(data)
+        : ((getCookie('service') || '').split(',') as ServiceToKorean[]).filter(
+            (i) => i,
+          ),
+    [data],
   );
 
   return (


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->
백엔드 avail_features 값 수정으로 인한 잔류 서비스 매칭 에러 수정

## 이슈 번호

- closes #191 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->
- 서비스 매핑 및 네비게이션 바 설정 로직 수정
